### PR TITLE
Blink 3 leds RGB

### DIFF
--- a/ports/Ai-Thinker/Ai-WB2-32S-Kit/projects/Ouput_Digital_Blink_Leds_RED_GREEN_and_BLUE/Ouput_Digital_Blink_Leds_RED_GREEN_and_BLUE.ino
+++ b/ports/Ai-Thinker/Ai-WB2-32S-Kit/projects/Ouput_Digital_Blink_Leds_RED_GREEN_and_BLUE/Ouput_Digital_Blink_Leds_RED_GREEN_and_BLUE.ino
@@ -1,0 +1,33 @@
+/*
+        TARJETA DE PROGRAMACIÓN Ai-WB2-32S-Kit
+
+                  DESCRIPCIÓN:
+
+     Ouput_Digital_Blink_Leds_RED_GREEN_and_BLUE.                              
+
+*/
+void setup() {
+  pinMode(14, OUTPUT);
+  pinMode(17, OUTPUT);
+  pinMode(3, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(14, HIGH);
+  delay(1000);
+
+  digitalWrite(14, LOW);
+  delay(1000);
+
+  digitalWrite(17, HIGH);
+  delay(2000);
+
+  digitalWrite(17, LOW);
+  delay(2000);
+
+  digitalWrite(3, HIGH);
+  delay(3000);
+
+  digitalWrite(3, LOW);
+  delay(3000);
+}


### PR DESCRIPTION
Se agrega código de programación con el parpadeó secuencial de los tres leds RGB incorporados en la tarjeta.